### PR TITLE
feat: Compress request body using gzip

### DIFF
--- a/src/hooks/compression.ts
+++ b/src/hooks/compression.ts
@@ -6,6 +6,8 @@ export class CompressionHook implements BeforeCreateRequestHook {
         const hdrs = new Headers(input.options?.headers ?? {});
         const body = input.options?.body;
 
+        // We'll need to handle streaming requests differently (per message).
+        // Currently we only handle unary JSON requests.
         if (!hdrs.get("content-type")?.toLowerCase().startsWith("application/json") || typeof body !== "string") {
             return input;
         }

--- a/src/hooks/compression.ts
+++ b/src/hooks/compression.ts
@@ -6,7 +6,7 @@ export class CompressionHook implements BeforeCreateRequestHook {
         const hdrs = new Headers(input.options?.headers ?? {});
         const body = input.options?.body;
 
-        if (hdrs.get("content-type") !== "application/json" || typeof body !== "string") {
+        if (!hdrs.get("content-type")?.toLowerCase().startsWith("application/json") || typeof body !== "string") {
             return input;
         }
 

--- a/src/hooks/compression.ts
+++ b/src/hooks/compression.ts
@@ -1,0 +1,31 @@
+import { RequestInput } from "../lib/http";
+import { BeforeCreateRequestContext, BeforeCreateRequestHook } from "./types";
+
+export class CompressionHook implements BeforeCreateRequestHook {
+    beforeCreateRequest(_hookCtx: BeforeCreateRequestContext, input: RequestInput): RequestInput {
+        const hdrs = new Headers(input.options?.headers ?? {});
+        const body = input.options?.body;
+
+        if (hdrs.get("content-type") !== "application/json" || typeof body !== "string") {
+            return input;
+        }
+
+        const stream = new Blob([body]).stream();
+        const compressedStream = stream.pipeThrough(new CompressionStream("gzip"));
+
+        // Set the content encoding.
+        hdrs.set("content-encoding", "gzip");
+
+        const opts = {
+            ...input.options,
+            body: compressedStream,
+            headers: hdrs,
+            duplex: "half", // use HTTP2 because of stream
+        };
+
+        return {
+            ...input,
+            options: opts,
+        }
+    }
+}

--- a/src/hooks/registration.ts
+++ b/src/hooks/registration.ts
@@ -1,3 +1,4 @@
+import { CompressionHook } from "./compression.js";
 import { Hooks } from "./types.js";
 
 /*
@@ -6,9 +7,9 @@ import { Hooks } from "./types.js";
  * in this file or in separate files in the hooks folder.
  */
 
-// @ts-expect-error remove this line when you add your first hook and hooks is used
 export function initHooks(hooks: Hooks) {
   // Add hooks by calling hooks.register{ClientInit/BeforeCreateRequest/BeforeRequest/AfterSuccess/AfterError}Hook
   // with an instance of a hook that implements that specific Hook interface
   // Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance
+  hooks.registerBeforeCreateRequestHook(new CompressionHook());
 }

--- a/src/index.extras.ts
+++ b/src/index.extras.ts
@@ -91,7 +91,7 @@ export type S2OperationConfig = {
 export enum AppendRetryPolicy {
     /**
      * Retry all eligible failures encountered during an append.
-     * This could result in append batches being duplicated on the stream.     
+     * This could result in append batches being duplicated on the stream.
      */
     All,
     /**
@@ -160,7 +160,7 @@ class S2Account {
         this.config.httpClient?.addHook("beforeRequest", (request) => {
             if (config?.authToken !== undefined) {
                 request.headers.set("Authorization", `Bearer ${config.authToken}`);
-            }            
+            }
         });
     }
 
@@ -269,7 +269,7 @@ class S2Basin {
         this.config.httpClient?.addHook("beforeRequest", (request) => {
             if (config?.authToken !== undefined) {
                 request.headers.set("Authorization", `Bearer ${config.authToken}`);
-            }            
+            }
         });
     }
 
@@ -353,7 +353,7 @@ class Stream {
         this.config.httpClient?.addHook("beforeRequest", (request) => {
             if (config?.authToken !== undefined) {
                 request.headers.set("Authorization", `Bearer ${config.authToken}`);
-            }            
+            }
         });
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": ".",
-    
 
     // https://github.com/tsconfig/bases/blob/a1bf7c0fa2e094b068ca3e1448ca2ece4157977e/bases/strictest.json
     "strict": true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `CompressionHook` to compress JSON request bodies using gzip and register it in the hook system.
> 
>   - **Compression**:
>     - Add `CompressionHook` class in `compression.ts` to compress JSON request bodies using gzip.
>     - Handles only unary JSON requests, not streaming requests.
>     - Sets `content-encoding` to `gzip` and uses HTTP2 for streaming.
>   - **Hook Registration**:
>     - Register `CompressionHook` in `initHooks()` in `registration.ts`.
>   - **Misc**:
>     - Remove trailing spaces in `index.extras.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-sdk-typescript&utm_source=github&utm_medium=referral)<sup> for 6d1c6fe6e5b5f3675beba0b092fa787715c576ab. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->